### PR TITLE
readme: fix URL to nixos-configs project

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ UNIX-philosophy.
 - [micro](https://github.com/zyedidia/micro) (for the terminal)
 
 ### NixOS Configs
-Feel free to check out my public [NixOS configs and dotfiles](<https://github.com/phip1611/nixos-config)!
+Feel free to check out my public [NixOS configs and dotfiles](https://github.com/phip1611/nixos-configs)!
 
 \
 *This README benefits from a service provided by https://github.com/anuraghazra/github-readme-stats - thanks to the original author(s)*.


### PR DESCRIPTION
there were two issues:
- the < before the URL prevent the []() syntax from working as intended, because there was no valid URL in the parentheses
- the URL pointed to phip1611/nixos-config, which does not exist